### PR TITLE
Fix: Added handling of PdfInteger for outlines

### DIFF
--- a/src/PdfSharp/Pdf/PdfOutline.cs
+++ b/src/PdfSharp/Pdf/PdfOutline.cs
@@ -414,7 +414,10 @@ namespace PdfSharp.Pdf
 #pragma warning disable 162
 
             // The destination page may not yet have been transformed to PdfPage.
-            PdfDictionary destPage = (PdfDictionary)((PdfReference)destination.Elements[0]).Value;
+            PdfDictionary destPage = (destination.Elements[0] is PdfInteger) ? 
+                destination.Owner.Pages[((PdfInteger)destination.Elements[0]).Value] : 
+                (PdfDictionary)((PdfReference)destination.Elements[0]).Value;
+
             PdfPage page = destPage as PdfPage;
             if (page == null)
                 page = new PdfPage(destPage);


### PR DESCRIPTION
I had a case where I merged multiple pdf files to one and added multilevel bookmarking at the same time. For some unknown(for me) reason with multilevel bookmarks there is sometimes PdfInteger instead of PdfReference and its causing:  
`System.InvalidCastException: 'Unable to cast object of type 'PdfSharp.Pdf.PdfInteger' to type 'PdfSharp.Pdf.Advanced.PdfReference'.'` At PdfOutline.SplitDestinationPage

I figured out the integer at least in my case was the actual page index so I added handling for that. In my case it did fix the problem.

![image](https://user-images.githubusercontent.com/16762892/85393901-6d130780-b556-11ea-9478-16ffbb53eab2.png)
